### PR TITLE
A few small fixes

### DIFF
--- a/src/bc-phone-number.js
+++ b/src/bc-phone-number.js
@@ -85,8 +85,8 @@ angular.module('bcPhoneNumber', ['bcPhoneNumberTemplates', 'ui.bootstrap'])
       });
 
       scope.$watch('number', function(newValue) {
-        ctrl.$setValidity('phoneNumber', bcCountries.isValidNumber(newValue));
         scope.isValid = bcCountries.isValidNumber(newValue);
+        ctrl.$setValidity('phoneNumber', scope.isValid);
       });
 
       scope.$watch('number', function(newValue) {

--- a/src/bc-phone-number.js
+++ b/src/bc-phone-number.js
@@ -15,7 +15,7 @@ angular.module('bcPhoneNumber', ['bcPhoneNumberTemplates', 'ui.bootstrap'])
 .directive('bcPhoneNumber', function() {
 
   if (typeof (bcCountries) === 'undefined') {
-    throw 'bc-countries not found, did you forget to load the Javascript?';
+    throw new Error('bc-countries not found, did you forget to load the Javascript?');
   }
 
   function getPreferredCountries(preferredCodes) {

--- a/src/bc-phone-number.js
+++ b/src/bc-phone-number.js
@@ -36,7 +36,7 @@ angular.module('bcPhoneNumber', ['bcPhoneNumberTemplates', 'ui.bootstrap'])
       preferredCountriesCodes: '@preferredCountries',
       defaultCountryCode: '@defaultCountry',
       selectedCountry: '=?',
-      isValid: '=',
+      isValid: '=?',
       ngModel: '=',
       ngChange: '&',
       ngDisabled: '=',
@@ -49,7 +49,7 @@ angular.module('bcPhoneNumber', ['bcPhoneNumberTemplates', 'ui.bootstrap'])
       scope.number = scope.ngModel;
       scope.changed = function() {
         scope.ngChange();
-      }
+      };
 
       if (scope.preferredCountriesCodes) {
         var preferredCodes = scope.preferredCountriesCodes.split(' ');

--- a/src/bc-phone-number.js
+++ b/src/bc-phone-number.js
@@ -15,7 +15,7 @@ angular.module('bcPhoneNumber', ['bcPhoneNumberTemplates', 'ui.bootstrap'])
 .directive('bcPhoneNumber', function() {
 
   if (typeof (bcCountries) === 'undefined') {
-    throw new('bc-countries not found, did you forget to load the Javascript?');
+    throw 'bc-countries not found, did you forget to load the Javascript?';
   }
 
   function getPreferredCountries(preferredCodes) {


### PR DESCRIPTION
Nothing too complicated here, just changing up the library so that:
- The error is properly [thrown](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw)
- Missing semicolon is added
- Mark `isValid` as optional (so that any callers don't generate errors when the attribute is missing)
- Avoid calling the same function twice